### PR TITLE
ADD: Outage events API specification

### DIFF
--- a/models/events.v1.json
+++ b/models/events.v1.json
@@ -1,0 +1,120 @@
+{
+  "type": "array",
+  "description": "",
+  "minItems": 0,
+  "uniqueItems": true,
+  "x-examples": {
+    "switch-example": [
+      {
+        "timestep": "1.0",
+        "event_type": "switch",
+        "affected_asset": "line.asset_name",
+        "event_data": {
+          "duration_ms": 100,
+          "type": "breaker",
+          "state": "open",
+          "dispatchable": true,
+          "pre_event_actions": [],
+          "post_event_actions": [
+            {
+              "timestep": "1.0",
+              "event_type": "loadshed",
+              "affected_asset": "load.asset_name",
+              "event_data": {
+                "status": 0
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "fault-example": [
+      {
+        "timestep": "1.0",
+        "event_type": "fault",
+        "affected_asset": "line.asset_name",
+        "event_data": {
+          "duration_ms": 100
+        }
+      }
+    ]
+  },
+  "items": {
+    "type": "object",
+    "properties": {
+      "timestep": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^\\d+\\.*\\d*",
+        "example": "1.0"
+      },
+      "event_type": {
+        "type": "string",
+        "minLength": 1,
+        "enum": [
+          "fault",
+          "switch"
+        ],
+        "example": "switch"
+      },
+      "affected_asset": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^\\w+\\.\\w+",
+        "example": "line.asset_name"
+      },
+      "event_data": {
+        "type": "object",
+        "properties": {
+          "duration_ms": {
+            "type": "number",
+            "minimum": -1,
+            "example": 100,
+            "format": "float",
+            "description": "Duration of a fault, in milliseconds, -1 ==> permanent fault"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of switch, e.g., \"fuse\", \"breaker\", \"recloser\", etc.",
+            "example": "breaker"
+          },
+          "state": {
+            "type": "string",
+            "description": "What is the state of the switch, \"open\" or \"closed\"? Only used if \"event_type\" is \"switch\".",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "example": "open"
+          },
+          "dispatchable": {
+            "type": "boolean",
+            "description": "Is the affected object dispatchable? (i.e., can be opened or closed), default is false"
+          },
+          "pre_event_actions": {
+            "$ref": "./events.v1.json"
+          },
+          "post_event_actions": {
+            "$ref": "./events.v1.json"
+          },
+          "status": {
+            "type": "integer",
+            "enum": [
+              0,
+              1
+            ],
+            "example": 1,
+            "description": "Status of the object, if 0, completely outaged from the model. Default 1.",
+            "default": 1
+          }
+        }
+      }
+    },
+    "required": [
+      "timestep",
+      "event_type",
+      "affected_asset",
+      "event_data"
+    ]
+  }
+}

--- a/models/outputs.v1.json
+++ b/models/outputs.v1.json
@@ -4,6 +4,7 @@
   "x-tags": [
     "output"
   ],
+  "description": "Main output schema for PowerModelsONM",
   "properties": {
     "simulation_time_steps": {
       "type": "array",
@@ -107,7 +108,9 @@
     },
     "summary_statistics": {
       "type": "object"
+    },
+    "events": {
+      "$ref": "./events.v1.json"
     }
-  },
-  "description": "Main output schema for PowerModelsONM"
+  }
 }

--- a/src/app/main.jl
+++ b/src/app/main.jl
@@ -49,7 +49,9 @@ function entrypoint(args::Dict{String,<:Any})
         Memento.setlevel!(Memento.getlogger(PowerModelsONM.PMD._PM), "error")
     end
 
-    data_eng, data_math = prepare_network_case(args["network-file"])
+    events = haskey(args, "events-file") ? parse_events(args["events-file"]) : Dict{String,Any}()
+
+    data_eng, data_math = prepare_network_case(args["network-file"]; events=events)
 
     form = get_formulation(args["formulation"])
     problem = get_problem(args["problem"], haskey(data_math, "nw"))
@@ -66,6 +68,8 @@ function entrypoint(args::Dict{String,<:Any})
     get_timestep_load_served!(output_data, sol_si, data_eng)
     get_timestep_generator_profiles!(output_data, sol_si)
     get_timestep_powerflow_output!(output_data, sol_si, data_eng)
+
+    output_data["events"] = events
 
     if !isempty(args["export"])
         open(args["export"], "w") do f

--- a/src/core/io.jl
+++ b/src/core/io.jl
@@ -1,5 +1,5 @@
 ""
-function prepare_network_case(network_file::String)::Tuple{Dict{String,Any},Dict{String,Any}}
+function prepare_network_case(network_file::String; events::Vector{Dict}=Vector{Dict}([]))::Tuple{Dict{String,Any},Dict{String,Any}}
     data_dss = PMD.parse_dss(network_file)
 
     # TODO: explicitly support DELTA connected generators in LPUBFDiag
@@ -13,9 +13,48 @@ function prepare_network_case(network_file::String)::Tuple{Dict{String,Any},Dict
 
     data_eng = PMD.parse_opendss(data_dss)
 
+    apply_events!(data_eng, events)
+
     PMD.apply_voltage_bounds!(data_eng)
 
     data_math = PMD.transform_data_model(data_eng; build_multinetwork=true)
 
     return data_eng, data_math
+end
+
+
+""
+function parse_events(events_file::String)::Vector{Dict{String,Any}}
+    open(events_file, "r") do f
+        JSON.parse(f)
+    end
+end
+
+
+""
+function apply_events!(network::Dict{String,Any}, events::Vector{Dict})
+    for event in events
+        source_id = event["affected_asset"]
+        asset_type, asset_name = split(source_id, ".")
+        timestep = event["timestep"]
+
+        if event["event_type"] == "switch"
+            start_timestep = Int(round(parse(Float64, timestep)))
+            if haskey(network, "nw")
+                for (n, nw) in network["nw"]
+                    if parse(Int, n) >= start_timestep
+                        nw["switch"][asset_name]["state"] = Dict{String,PMD.SwitchState}("closed"=>PMD.CLOSED, "open"=>PMD.OPEN)
+                        if haskey(event["event_data"], "dispatchable")
+                            nw["switch"][asset_name]["dispatchable"] = event["event_data"]["dispatchable"] ? PMD.YES : PMD.NO
+                        end
+                    end
+                end
+            else
+                network["switch"][asset_name]["state"] = Dict{String,PMD.SwitchState}("closed"=>PMD.CLOSED, "open"=>PMD.OPEN)
+            end
+
+        else
+            @warn "event of type '$(event["event_type"])' is not yet supported in PowerModelsONM"
+        end
+    end
 end


### PR DESCRIPTION
Adds a new API model specification for inputs/outputs of
contingency type events.

The following are two initial examples of the usage of this format:

```json
[
  {
    "timestep": "1.0",
    "event_type": "switch",
    "affected_asset": "line.asset_name",
    "event_data": {
      "duration_ms": 100,
      "type": "breaker",
      "state": "open",
      "dispatchable": true,
      "pre_event_actions": [],
      "post_event_actions": [
        {
          "timestep": "1.0",
          "event_type": "loadshed",
          "affected_asset": "load.asset_name",
          "event_data": {
            "status": 0
          }
        }
      ]
    }
  }
]
```

and

```json
[
  {
    "timestep": "1.0",
    "event_type": "fault",
    "affected_asset": "line.asset_name",
    "event_data": {
      "duration_ms": 100
    }
  }
]
```